### PR TITLE
fix: adjust metax kernel symbol usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ set (CMAKE_CXX_STANDARD 20)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package (Threads REQUIRED)
-find_library (DL_LIB dl REQUIRED)
 
 # CUDA is only required for NVIDIA vendor
 if (PHXFS_VENDOR STREQUAL "NVIDIA")
@@ -122,12 +121,14 @@ if (PHXFS_VENDOR STREQUAL "NVIDIA")
 endif ()
 
 # Set vendor-specific backend object file and compile define
+set (VENDOR_KERNEL_MODULE "")
 if (PHXFS_VENDOR STREQUAL "NVIDIA")
     set (VENDOR_BACKEND "nvidia-backend.o")
     set (VENDOR_DEFINE "CONFIG_PHXFS_VENDOR_NVIDIA")
 elseif (PHXFS_VENDOR STREQUAL "METAX")
     set (VENDOR_BACKEND "metax-backend.o")
     set (VENDOR_DEFINE "CONFIG_PHXFS_VENDOR_METAX")
+    set (VENDOR_KERNEL_MODULE "/opt/mxdriver/kernel_module/${CMAKE_SYSTEM_VERSION}/Module.symvers")
 elseif (PHXFS_VENDOR STREQUAL "AMD")
     set (VENDOR_BACKEND "amd-backend.o")
     set (VENDOR_DEFINE "CONFIG_PHXFS_VENDOR_AMD")
@@ -257,7 +258,7 @@ target_include_directories(libphoenix PRIVATE "${libphoenix_root}")
 # The library itself depends on cudart (nvidia_connector) and pthreads (io
 # pool); declare them as link deps so libphoenix.so carries the right
 # DT_NEEDED and can be dlopen()'d standalone (P1-2), not left to consumers.
-target_link_libraries(libphoenix Threads::Threads)
+target_link_libraries(libphoenix Threads::Threads ${CMAKE_DL_LIBS})
 if (PHXFS_VENDOR STREQUAL "NVIDIA")
     target_link_libraries(libphoenix CUDA::cudart)
     # NVTX ranges (phx.batch.*, phx.staging.*) for nsys. NVTX v3 is

--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -10,7 +10,7 @@ KERNEL_SRC := /lib/modules/$(KVER)/build
 all: phxfs
 
 phxfs: configure
-	$(MAKE) -C $(KERNEL_SRC) M=@module_output@ modules
+	$(MAKE) -C $(KERNEL_SRC) M=@module_output@ modules KBUILD_EXTRA_SYMBOLS=@VENDOR_KERNEL_MODULE@
 configure:
 	@ @module_root@/configure $(KVER) @module_root@
 # Optional MAP_MODE=0|1 overrides the baked-in default BAR map mode for this load

--- a/module/metax-backend.c
+++ b/module/metax-backend.c
@@ -3,13 +3,13 @@
  *
  * Wraps the METAX driver's P2P API behind the
  * vendor-agnostic phxfs_p2p_ops interface.
- */
+*/
 
 #include <linux/module.h>
 #include <linux/pci.h>
-#include <linux/scatterlist.h>
 #include <linux/slab.h>
 
+#include "metax-p2p.h"
 #include "phxfs-backend.h"
 #include "phxfs.h"       /* phxfs_err / phxfs_info */
 
@@ -23,98 +23,16 @@ struct metax_p2p_page_table {
 	uint32_t entries;
 };
 
-/* Function pointer types for METAX P2P symbols (loaded via __symbol_get) */
-typedef int (*metax_p2p_acquire_mem_fptr)(uint64_t, size_t, void **, int (*)(void *), void *);
-typedef int (*metax_p2p_get_mem_fptr)(void *, struct sg_table **);
-typedef int (*metax_p2p_put_mem_fptr)(void *, struct sg_table *);
-typedef uint64_t (*metax_p2p_get_bus_offset_fptr)(void *);
-typedef uint32_t (*metax_p2p_get_page_size_fptr)(void *);
-typedef void (*metax_p2p_release_mem_fptr)(void *);
-
-/* ------------------------------------------------------------------ */
-/* METAX P2P symbol pointers (loaded via __symbol_get)               */
-/* ------------------------------------------------------------------ */
-
-static metax_p2p_acquire_mem_fptr    metax_p2p_acquire_mem_p;
-static metax_p2p_get_mem_fptr        metax_p2p_get_mem_p;
-static metax_p2p_put_mem_fptr        metax_p2p_put_mem_p;
-static metax_p2p_get_bus_offset_fptr metax_p2p_get_bus_offset_p;
-static metax_p2p_get_page_size_fptr  metax_p2p_get_page_size_p;
-static metax_p2p_release_mem_fptr    metax_p2p_release_mem_p;
-
-#ifdef HAVE_MODULE_MUTEX
-extern struct mutex module_mutex;
-#endif
-
-static void metax_put_symbols(void)
-{
-	if (metax_p2p_acquire_mem_p)    __symbol_put("metax_p2p_acquire_mem");
-	if (metax_p2p_get_mem_p)        __symbol_put("metax_p2p_get_mem");
-	if (metax_p2p_put_mem_p)        __symbol_put("metax_p2p_put_mem");
-	if (metax_p2p_get_bus_offset_p) __symbol_put("metax_p2p_get_bus_offset");
-	if (metax_p2p_get_page_size_p)  __symbol_put("metax_p2p_get_page_size");
-	if (metax_p2p_release_mem_p)    __symbol_put("metax_p2p_release_mem");
-
-	metax_p2p_acquire_mem_p    = NULL;
-	metax_p2p_get_mem_p        = NULL;
-	metax_p2p_put_mem_p        = NULL;
-	metax_p2p_get_bus_offset_p = NULL;
-	metax_p2p_get_page_size_p  = NULL;
-	metax_p2p_release_mem_p    = NULL;
-}
-
-static int metax_load_symbols(void)
-{
-#ifdef HAVE_MODULE_MUTEX
-	mutex_lock(&module_mutex);
-#endif
-	metax_p2p_acquire_mem_p = __symbol_get("metax_p2p_acquire_mem");
-	if (!metax_p2p_acquire_mem_p) goto err;
-
-	metax_p2p_get_mem_p = __symbol_get("metax_p2p_get_mem");
-	if (!metax_p2p_get_mem_p) goto err;
-
-	metax_p2p_put_mem_p = __symbol_get("metax_p2p_put_mem");
-	if (!metax_p2p_put_mem_p) goto err;
-
-	metax_p2p_get_bus_offset_p = __symbol_get("metax_p2p_get_bus_offset");
-	if (!metax_p2p_get_bus_offset_p) goto err;
-
-	metax_p2p_get_page_size_p = __symbol_get("metax_p2p_get_page_size");
-	if (!metax_p2p_get_page_size_p) goto err;
-
-	metax_p2p_release_mem_p = __symbol_get("metax_p2p_release_mem");
-	if (!metax_p2p_release_mem_p) goto err;
-
-#ifdef HAVE_MODULE_MUTEX
-	mutex_unlock(&module_mutex);
-#endif
-	return 0;
-
-err:
-#ifdef HAVE_MODULE_MUTEX
-	mutex_unlock(&module_mutex);
-#endif
-	metax_put_symbols();
-	return -ENOSYS;
-}
-
 /* ------------------------------------------------------------------ */
 /* phxfs_p2p_ops implementation                                       */
 /* ------------------------------------------------------------------ */
 
 static int metax_init(void)
 {
-	int ret = metax_load_symbols();
-	if (ret)
-		phxfs_err("phxfs: failed to load metax_p2p symbols\n");
-	return ret;
+	return 0;
 }
 
-static void metax_exit(void)
-{
-	metax_put_symbols();
-}
+static void metax_exit(void) {}
 
 static int metax_acquire_callback_wrapper(void *arg)
 {
@@ -136,11 +54,6 @@ static int metax_p2p_get_pages_p(uint64_t vaddr,
 	uint32_t page_size;
 	uint32_t virtual_entries;
 
-	if(metax_p2p_acquire_mem_p == NULL || metax_p2p_get_mem_p == NULL ||
-			metax_p2p_get_page_size_p == NULL) {
-		return -ENOMEM;
-	}
-
 	pt = kmalloc(sizeof(struct metax_p2p_page_table), GFP_KERNEL);
 	if (pt == NULL) {
 		phxfs_err("Failed to allocate page table\n");
@@ -150,8 +63,8 @@ static int metax_p2p_get_pages_p(uint64_t vaddr,
 	pt->free_cb = free_cb;
 	pt->data = data;
 
-	err = metax_p2p_acquire_mem_p(vaddr, length, &pt->handle, metax_acquire_callback_wrapper, pt);
-	phxfs_info("metax_p2p_acquire_mem_p: vaddr=0x%llx, length=0x%llx, handle=%p, pt=%p, err=%d\n",
+	err = metax_p2p_acquire_mem(vaddr, length, &pt->handle, metax_acquire_callback_wrapper, pt);
+	phxfs_info("metax_p2p_acquire_mem: vaddr=0x%llx, length=0x%llx, handle=%p, pt=%p, err=%d\n",
 		 vaddr, length, pt->handle, pt, err);
 	if (err != 0) {
 		phxfs_err("metax_p2p_acquire_mem failed: %d\n", err);
@@ -159,24 +72,22 @@ static int metax_p2p_get_pages_p(uint64_t vaddr,
 		return err;
 	}
 
-	err = metax_p2p_get_mem_p(pt->handle, &pt->sgt);
-	phxfs_info("metax_p2p_get_mem_p: handle=%p, sgt=%p, err=%d\n", pt->handle, pt->sgt, err);
+	err = metax_p2p_get_mem(pt->handle, &pt->sgt);
+	phxfs_info("metax_p2p_get_mem: handle=%p, sgt=%p, err=%d\n", pt->handle, pt->sgt, err);
 	if (err != 0) {
 		phxfs_err("metax_p2p_get_mem failed: %d\n", err);
-		if(metax_p2p_release_mem_p)
-			metax_p2p_release_mem_p(pt->handle);
+		metax_p2p_release_mem(pt->handle);
 		kfree(pt);
 		return err;
 	}
 
-	page_size = metax_p2p_get_page_size_p(pt->handle);
-	phxfs_info("metax_p2p_get_page_size_p: handle=%p, page_size=%u\n", pt->handle, page_size);
-	if (page_size == 0) {
+	page_size = metax_p2p_get_page_size(pt->handle);
+	phxfs_info("metax_p2p_get_page_size: handle=%p, page_size=%u\n", pt->handle, page_size);
+	if (page_size == 0)
 		page_size = 1 << 16;
-	}
 	virtual_entries = length / page_size;
 	pt->virtual_entries = virtual_entries;
-    phxfs_info("metax_p2p_get_page_size_p: handle=%p, virtual_entries=%u\n", pt->handle, virtual_entries);
+    phxfs_info("metax_p2p_get_page_size: handle=%p, virtual_entries=%u\n", pt->handle, virtual_entries);
 
 	pt->page_size = ((struct p2p_vmap*)data)->page_size;
 	*page_table = pt;
@@ -213,17 +124,13 @@ static int metax_p2p_put_pages_p(uint64_t vaddr,
 	}
 
 	if (page_table->sgt != NULL) {
-		if(metax_p2p_put_mem_p) {
-			phxfs_info("metax_p2p_put_mem_p: handle=%p, sgt=%p\n", page_table->handle, page_table->sgt);
-			metax_p2p_put_mem_p(page_table->handle, page_table->sgt);
-		}
+		phxfs_info("metax_p2p_put_mem: handle=%p, sgt=%p\n", page_table->handle, page_table->sgt);
+		metax_p2p_put_mem(page_table->handle, page_table->sgt);
 	}
 
 	if (page_table->handle != NULL) {
-		if(metax_p2p_release_mem_p) {
-			phxfs_info("metax_p2p_release_mem_p: handle=%p\n", page_table->handle);
-			metax_p2p_release_mem_p(page_table->handle);
-		}
+		phxfs_info("metax_p2p_release_mem: handle=%p\n", page_table->handle);
+		metax_p2p_release_mem(page_table->handle);
 	}
 
 	kfree(page_table);
@@ -253,12 +160,8 @@ static int metax_p2p_dma_map_pages_p(struct metax_p2p_page_table *page_table,
 		return -EINVAL;
 	}
 
-	if(metax_p2p_get_bus_offset_p == NULL) {
-		return -ENOMEM;
-	}
-
-	offset = metax_p2p_get_bus_offset_p(page_table->handle);
-	phxfs_info("metax_p2p_get_bus_offset_p: handle=%p, offset=0x%llx\n",
+	offset = metax_p2p_get_bus_offset(page_table->handle);
+	phxfs_info("metax_p2p_get_bus_offset: handle=%p, offset=0x%llx\n",
 		 page_table->handle, offset);
 
 	dma_addrs = kmalloc(request_naddr * sizeof(uint64_t), GFP_KERNEL);
@@ -344,10 +247,9 @@ static struct phxfs_p2p_ops metax_p2p_ops =
 	.page_size       = 64 * 1024,  /* METAX GPU page = 64 KiB */
 };
 
+int metax_backend_register(void);
+
 int metax_backend_register(void)
 {
-	int ret = metax_init();
-	if (ret)
-		return ret;
 	return phxfs_p2p_register_backend(&metax_p2p_ops);
 }

--- a/module/metax-p2p.h
+++ b/module/metax-p2p.h
@@ -1,0 +1,75 @@
+/*
+ * METAX P2P Backend Header File
+*/
+
+#include <linux/scatterlist.h>
+
+/*
+* 通知 GPU driver 要访问的 mem 区域，不允许跨进程访问，所以没有进程相关参数
+*
+* @addr[in]: GPU 虚拟地址
+* @size[in]： GPU 虚拟地址长度
+* @handle[out]: 由 GPU driver 分配并设置, 表示 addr/size 代表的内存区域, 后续调用其它接口时，使用这个参数表示此内存区域
+* @callback[in]: GPU driver 回收内存时，调用此接口，peer 端阻塞直到 IO 完成，内存可以释放，如果长时间 io 不能结束，返回 -ETIMEOUT, 成功返回 0
+* @arg[in]: GPU driver 调用 callback 时传的参数
+* @return
+*   0 success
+*   <0 errno code
+*/
+int metax_p2p_acquire_mem(uint64_t addr, size_t size, void **handle, int (*callback)(void *arg), void *arg);
+
+
+/*
+* pin 住 mem 区域并获取总线地址
+*
+* @handle[in] - metax_p2p_acquire_mem 获取的句柄
+* @sgt[out] - 表示 bus 地址的 sg table，由 GPU driver 设置并分配, 存储侧可以结合 metax_p2p_get_page_size 返回的 page size 转成成
+*             定长数组的形式，sg table 里的地址/长度都是 page size 对齐的
+* @return
+*   0 success
+*   <0 errno code
+*/
+int metax_p2p_get_mem(void *handle, struct sg_table **sgt);
+
+
+/*
+* unpin mem
+*
+* @handle[in] - metax_p2p_acquire_mem 获取的句柄
+* @sgt[in] - metax_p2p_get_mem 获取的 sgt, 可以是 NULL
+* @return
+*   0 success
+*   <0 errno code
+*/
+int metax_p2p_put_mem(void *handle, struct sg_table *sgt);
+
+
+/*
+* 获取 mem 区域 bus 地址到 cpu 地址的 offset
+*
+* @handle[in] - metax_p2p_acquire_mem 获取的句柄
+* @return
+*   bus 地址到 cpu 地址的 offset, bus 地址加上此 offset 可以得到 cpu 地址
+*/
+uint64_t metax_p2p_get_bus_offset(void *handle);
+
+
+/*
+* 获取 mem 区域的 page size, metax_p2p_get_mem 后调用
+*
+* @handle[in] - metax_p2p_acquire_mem 获取的句柄
+* @return
+*   mem 区域的 page size
+*/
+uint32_t metax_p2p_get_page_size(void *handle);
+
+
+/*
+* 通知 GPU driver mem 区域使用完毕
+*
+* @handle[in] - metax_p2p_acquire_mem 获取的句柄
+* @return
+*   0 success
+*   <0 errno code
+*/
+void metax_p2p_release_mem(void *handle);


### PR DESCRIPTION
per metax kernel symbol license constraint with linux kernel version >= 6.8