### PR TITLE
fix: update BAR mapping mode acquisition in test_regmem

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,10 +5,6 @@ if (PHXFS_VENDOR STREQUAL "NVIDIA")
     find_package (CUDA 12.4 REQUIRED)
 endif ()
 
-if (PHXFS_MAP_MODE STREQUAL "staging")
-	set (PHXFS_MAP_MODE_STAGING ON)
-endif ()
-
 set (phoenix_root "${PROJECT_SOURCE_DIR}/..")
 set (phoenix_include "${phoenix_root}/libphoenix/include")
 

--- a/test/test_regmem.cu
+++ b/test/test_regmem.cu
@@ -173,11 +173,11 @@ static void test_dereg_unregistered(int dev_id) {
 
     // Deregister without registering first
     int ret = phxfs_deregmem(dev_id, gpu_buf, size);
-#ifndef PHXFS_MAP_MODE_STAGING
-      CHECK(ret != 0, "deregmem of unregistered memory correctly fails");
-#else
-      CHECK(ret == 0, "deregmem of unregistered memory correctly succeeds");
-#endif
+    if (phxfs_get_map_mode(dev_id) == 0)
+        CHECK(ret != 0, "deregmem of unregistered memory correctly fails");
+    else
+        CHECK(ret == 0, "deregmem of unregistered memory correctly succeeds");
+
     cudaFree(gpu_buf);
 }
 


### PR DESCRIPTION
as bar mapping mode could be different when loading phoenixfs.ko than build-time